### PR TITLE
Add data to callback and include thumbnails

### DIFF
--- a/directus-download.js
+++ b/directus-download.js
@@ -424,7 +424,7 @@ class DirectusDownload {
         }
 
         this.downloadMedia()
-            .then(this.opts.callback);
+            .then(this.opts.callback(data));
 
     }
 };

--- a/example.js
+++ b/example.js
@@ -1,23 +1,19 @@
-var dsdownload = require('./directus-download');
+let dsdownload = require('./directus-download');
 
 dsdownload({
-    dataPath: './data/data.json',
-    mediaPath: './media/', // This is used for saving the file
+    dataPath: './test/data/data.json',
+    mediaPath: './test/media/', // This is used for saving the file
     mediaBookPath: 'media/', // And this is used for replacing
     csvPath: false,
     prettifyJson: false,
     skipExistingFiles: true,
-    useImageObjects: false, //return full directus file object instead of the url as a string only
-    baseUrl: '',
-    apiUrl: '',
+    useImageObjects: true, //return full directus file object instead of the url as a string only
+    baseUrl: 'https://labs.volkskrant.nl',
+    apiUrl: 'https://labs.volkskrant.nl/directus/',
     accessToken: false, // only required when requesting non-publically available endpoints
+    downloadThumbnails: 400,
     items: [
-        {
-            api: 'tablename', // pass an object when only requesting 1 item from a table
-            id: 'id-here',
-            name: 'alternatename'
-        },
-        'tablename' // when requesting all rows
+        'aarsman' // when requesting all rows
     ],
     callback: function () {
         console.log('this is ready');


### PR DESCRIPTION
Allow to auto-generate thumbnails using a predefined array of allowed thumbnail sizes (that match server settings). 

Also, provide the callback function with the downloaded data.